### PR TITLE
IDP-584 - Sha pinned github action version

### DIFF
--- a/.github/workflows/ci-aspnetcore.yml
+++ b/.github/workflows/ci-aspnetcore.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
+        uses: actions/checkout@v3 # v3
 
       - name: Setup Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3

--- a/.github/workflows/ci-aspnetcore.yml
+++ b/.github/workflows/ci-aspnetcore.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
+        uses: actions/checkout@v3
 
       - name: Setup Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
+        uses: azure/setup-helm@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -46,15 +46,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
+        uses: actions/checkout@v3
 
       - name: Setup Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
+        uses: azure/setup-helm@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Kubernetes ${{ matrix.kubernetesVersion }} Kind cluster
-        uses: helm/kind-action@main
+        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140
         with:
           node_image: ${{ matrix.kindImage }}
 

--- a/.github/workflows/ci-aspnetcore.yml
+++ b/.github/workflows/ci-aspnetcore.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3 # v3
+        uses: actions/checkout@v3
 
       - name: Setup Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3

--- a/.github/workflows/ci-aspnetcore.yml
+++ b/.github/workflows/ci-aspnetcore.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
 
       - name: Setup Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci-aspnetcore.yml
+++ b/.github/workflows/ci-aspnetcore.yml
@@ -54,7 +54,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Kubernetes ${{ matrix.kubernetesVersion }} Kind cluster
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140
+        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1
         with:
           node_image: ${{ matrix.kindImage }}
 

--- a/renovate.json
+++ b/renovate.json
@@ -24,8 +24,7 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "groupName": "Pipeline dependencies",
-      "pinDigests": true
+      "groupName": "Pipeline dependencies"
     }
   ]
 }


### PR DESCRIPTION
## Context
We got a [security warning](https://github.com/gsoft-inc/gsoft-helm-charts/security/code-scanning/1) mentioning that this action being from a third party is safer to use with a full sha commit id that just a short version identifier.

## What changed
- Update helm/kind-action to full sha version