### PR TITLE
[IDP-1068] fix: output Azure Entra ID workload identity's client ID in annotations

### DIFF
--- a/charts/aspnetcore/templates/serviceaccount.yaml
+++ b/charts/aspnetcore/templates/serviceaccount.yaml
@@ -9,12 +9,16 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if .Values.azureWorkloadIdentity.enabled }}
+    # https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview#pod-labels
     azure.workload.identity/use: "true"
+    {{- end }}
+  annotations:
+    {{- if .Values.azureWorkloadIdentity.enabled }}
     {{- if .Values.azureWorkloadIdentity.clientId }}
+    # https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview#service-account-annotations
     azure.workload.identity/client-id: {{ .Values.azureWorkloadIdentity.clientId | quote }}
     {{- end }}
     {{- end }}
-  annotations:
     {{- with .Values.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
# Description of changes
Output the client ID for Azure Entra ID Workload Identity in the `ServiceAccount`'s `annotations` rather than `labels` to conform with its expectations and prevent configuration overrides in repositories that would consume the current chart

# Breaking changes
N/A