### PR TITLE
IDP-1416 Parametrize key vault object name

### DIFF
--- a/charts/aspnetcore/Chart.yaml
+++ b/charts/aspnetcore/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspnetcore
 description: A generic Helm chart for ASP.NET Core services
-version: 1.0.5
+version: 1.0.6
 home: https://github.com/gsoft-inc/gsoft-helm-charts
 sources:
   - https://github.com/gsoft-inc/gsoft-helm-charts

--- a/charts/aspnetcore/templates/secretproviderclass.yaml
+++ b/charts/aspnetcore/templates/secretproviderclass.yaml
@@ -7,12 +7,12 @@ spec:
   provider: azure
   parameters:
     usePodIdentity: "false"
-    clientID: {{ .Values.azureWorkloadIdentity.clientId }}
-    keyvaultName: {{ .Values.certificateStore.keyvaultName }}
+    clientID: {{ quote .Values.azureWorkloadIdentity.clientId }}
+    keyvaultName: {{ quote .Values.certificateStore.keyvaultName }}
     objects:  |
       array:
         - |
-          objectName: INTERNAL_DNS_CERTIFICATE_NAME
+          objectName: {{ quote .Values.certificateStore.keyvaultObjectName }}
           objectType: cert
-    tenantId: {{ .Values.certificateStore.tenantId }}
+    tenantId: {{ quote .Values.certificateStore.tenantId }}
 {{- end }}

--- a/charts/aspnetcore/values.yaml
+++ b/charts/aspnetcore/values.yaml
@@ -185,7 +185,9 @@ extraVolumeMounts: []
 ## @param certificateStore.enabled Whether or not to replace the container's certificate store with Workleap's
 ## @param certificateStore.tenantId The id of the azure tenant the Key Vault containing the certificate store is located in
 ## @param certificateStore.keyvaultName The name of the Key Vault containing the certificate store
+## @param certificateStore.keyvaultObjectName The name of the object in the Key Vault containing the certificate
 certificateStore:
   enabled: false
   tenantId: ""
   keyvaultName: ""
+  keyvaultObjectName: ""


### PR DESCRIPTION
I didn't realize that `INTERNAL_DNS_CERTIFICATE_NAME` was a placeholder value while integrating this from our internal documentation. This has been replaced by `certificateStore.keyvaultObjectName` in the helm values.