### PR TITLE
IDP-2148 Allow defining additional ingress paths

### DIFF
--- a/charts/aspnetcore/Chart.yaml
+++ b/charts/aspnetcore/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspnetcore
 description: A generic Helm chart for ASP.NET Core services
-version: 2.0.0
+version: 2.1.0
 home: https://github.com/gsoft-inc/gsoft-helm-charts
 sources:
   - https://github.com/gsoft-inc/gsoft-helm-charts

--- a/charts/aspnetcore/templates/ingress.yaml
+++ b/charts/aspnetcore/templates/ingress.yaml
@@ -34,4 +34,13 @@ spec:
                 name: {{ .Release.Name }}-service
                 port:
                   number: {{ .Values.service.port }}
+          {{- range .Values.ingress.additionalPaths }}
+          - path: {{ . }}
+            pathType: {{ $.Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $.Release.Name }}-service
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
 {{- end }}

--- a/charts/aspnetcore/values.yaml
+++ b/charts/aspnetcore/values.yaml
@@ -42,6 +42,7 @@ service:
 ## @param ingress.className IngressClass that will be be used to implement the Ingress
 ## @param ingress.hostname Default host for the ingress resource, a host pointing to this will be created
 ## @param ingress.path Default path for the ingress record
+## @param ingress.additionalPaths Additional paths pointing to the same service for the ingress record
 ## @param ingress.pathType Ingress path type
 ## @param ingress.annotations Additional annotations for the Ingress resource, for example nginx ingress annotations
 ## @param ingress.tls.enabled Enable TLS configuration for the host defined at `ingress.hostname` parameter
@@ -53,6 +54,7 @@ ingress:
   className: nginx
   hostname: aspnetcore.example.local
   path: /
+  additionalPaths: []
   pathType: Prefix
   annotations: {}
   tls:


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
Added support for additional ingress paths pointing to the same service, this feature was requested by a user needing to run a service on a certain endpoint that isn't the root (`/`) while also receiving requests for a background worker at different path from the root (e.g. `/other-background-worker`).

I considered replacing the value at `ingress.path` with a list at `ingress.paths` but decided against it for the sake of not introducing a breaking change that will affect more users than the number of users who need this more niche feature. Instead, this PR introduces `ingress.additionalPaths` which will add additional paths pointing to the same service.

## Additional checks
Rendered chart (`helm template test aspnetcore --set ingress.path=/some-service --set 'ingress.additionalPaths={/an-endpoint,/some-other-endpoint}'`):
```yaml
---
# Source: aspnetcore/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test-ingress
  labels:
    helm.sh/chart: aspnetcore-2.1.0
    app.kubernetes.io/name: aspnetcore
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "aspnetapp"
    app.kubernetes.io/managed-by: Helm
  annotations:
spec:
  ingressClassName: nginx
  rules:
    - host: "aspnetcore.example.local"
      http:
        paths:
          - path: /some-service
            pathType: Prefix
            backend:
              service:
                name: test-service
                port:
                  number: 80
          - path: /an-endpoint
            pathType: Prefix
            backend:
              service:
                name: test-service
                port:
                  number: 80
          - path: /some-other-endpoint
            pathType: Prefix
            backend:
              service:
                name: test-service
                port:
                  number: 80
```

- [x] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
