### PR TITLE
IDP-2209 Bump default replicas to 2

### DIFF
--- a/charts/aspnetcore/Chart.yaml
+++ b/charts/aspnetcore/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspnetcore
 description: A generic Helm chart for ASP.NET Core services
-version: 2.1.0
+version: 2.1.1
 home: https://github.com/gsoft-inc/gsoft-helm-charts
 sources:
   - https://github.com/gsoft-inc/gsoft-helm-charts

--- a/charts/aspnetcore/values.yaml
+++ b/charts/aspnetcore/values.yaml
@@ -1,6 +1,7 @@
 ## @param replicaCount Number of ASP.NET Core replicas to deploy
 ##
-replicaCount: 1
+## We set this to 2 by default because the PodDisruptionBudget is set to minimum 1 running replica and having only one replica creates a deadlock while draining nodes during cluster upgrades
+replicaCount: 2
 
 ## @param environment The ASP.NET Core environment name (DOTNET_ENVIRONMENT)
 ##


### PR DESCRIPTION
We set this to 2 by default because the `PodDisruptionBudget` is set to minimum 1 running replica and having only one replica creates a deadlock while draining nodes during cluster upgrades.