### PR TITLE
add optional hpa autoscaler support.

### DIFF
--- a/charts/aspnetcore/Chart.yaml
+++ b/charts/aspnetcore/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspnetcore
 description: A generic Helm chart for ASP.NET Core services
-version: 2.2.0
+version: 2.3.0
 home: https://github.com/gsoft-inc/gsoft-helm-charts
 sources:
   - https://github.com/gsoft-inc/gsoft-helm-charts

--- a/charts/aspnetcore/templates/deployment-hpa.yaml
+++ b/charts/aspnetcore/templates/deployment-hpa.yaml
@@ -1,0 +1,24 @@
+{{- if (((.Values.deployment).autoscaling).enabled) }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-hpa
+  annotations:
+    {{- with .Values.commonAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: {{ .Values.deployment.autoscaling.targetCPUUtilizationPercentage }}
+          type: Utilization
+      type: Resource
+  minReplicas: {{ max (add ((.Values.podDisruptionBudget).minAvailable) 1) (.Values.deployment.autoscaling.minReplicas) }}
+  maxReplicas: {{ max (add ((.Values.podDisruptionBudget).minAvailable) 1) (.Values.deployment.autoscaling.minReplicas) (.Values.deployment.autoscaling.maxReplicas) }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ default (printf "%s-deployment" .Release.Name) .Values.deployment.name }}
+{{- end }}

--- a/charts/aspnetcore/values.yaml
+++ b/charts/aspnetcore/values.yaml
@@ -66,9 +66,19 @@ ingress:
 
 ## ASP.NET Core deployment parameters
 ## @param deployment.name Name of the deployment, automatically generated from the release name if not specified
+## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+## @param deployment.autoscaling.enabled Default to false. Enable autoscaling
+## @param deployment.autoscaling.minReplicas Optional if PodDistributionBudget is set. Minimum number of ASP.NET Core replicas minimum is PodDisruptionBudget.minAvailable + 1
+## @param deployment.autoscaling.maxReplicas Optional if PodDistributionBudget is set or minReplicas is set. Maximum number of ASP.NET Core replicas minimum is minReplicas value.
+## @param deployment.autoscaling.targetCPUUtilizationPercentage Target CPU utilization percentage for autoscaling
 ##
 deployment:
   name: ""
+  autoscaling:
+    enabled: true
+    #minReplicas: 2
+    #maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
 
 ## ASP.NET Core containers' resource requests and limits defined in YAML
 ## ref: https://kubernetes.io/docs/user-guide/compute-resources/

--- a/charts/aspnetcore/values.yaml
+++ b/charts/aspnetcore/values.yaml
@@ -75,7 +75,7 @@ ingress:
 deployment:
   name: ""
   autoscaling:
-    enabled: true
+    enabled: false
     #minReplicas: 2
     #maxReplicas: 3
     targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
deploy an HorizontalPodAutoscaler that integrate without bubbling with PodDistribution budget.

the feature is Opt-in.

the hpa rules:
- minimal replicas is always is 1 more than the PodDistribution to avoid locking deployments
- max replicas at least equal to or greater than min replicas.

scaling only support target cpu for now.