### PR TITLE
IDP-2760 Mount certificate store from ConfigMap instead of Azure Files

### DIFF
--- a/charts/aspnetcore/Chart.yaml
+++ b/charts/aspnetcore/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspnetcore
 description: A generic Helm chart for ASP.NET Core services
-version: 2.3.0
+version: 3.0.0
 home: https://github.com/gsoft-inc/gsoft-helm-charts
 sources:
   - https://github.com/gsoft-inc/gsoft-helm-charts

--- a/charts/aspnetcore/templates/deployment.yaml
+++ b/charts/aspnetcore/templates/deployment.yaml
@@ -91,15 +91,13 @@ spec:
       volumes:
       {{- if .Values.certificateStore.enabled }}
       - name: certificate-store
-        csi:
-          driver: file.csi.azure.com
-          volumeAttributes:
-            subscriptionID: {{ quote .Values.certificateStore.subscriptionId }}
-            resourceGroup: {{ quote .Values.certificateStore.resourceGroup }}
-            storageAccount: {{ quote .Values.certificateStore.storageAccount }}
-            shareName: {{ quote .Values.certificateStore.shareName }}
-            clientID: {{ quote .Values.azureWorkloadIdentity.clientId }}
-            mountOptions: "dir_mode=0777,file_mode=0777,cache=strict,actimeo=30,nosharesock"
+        configMap:
+          name: {{ .Values.certificateStore.configMapName }}
+          defaultMode: 0644
+          optional: false
+          items:
+          - key: {{ .Values.certificateStore.fileName }}
+            item: {{ .Values.certificateStore.fileName }}
       {{- end }}
       {{- if .Values.extraVolumes}}
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/charts/aspnetcore/values.yaml
+++ b/charts/aspnetcore/values.yaml
@@ -199,17 +199,11 @@ extraVolumes: []
 ##
 extraVolumeMounts: []
 
-## Replace the container's certificate store with Workleap's certificate store which is stored in an Azure File Share
+## Replace the container's certificate store with Workleap's certificate store which is stored in a ConfigMap created by trust-manager
 ## @param certificateStore.enabled Whether or not to replace the container's certificate store with Workleap's
-## @param certificateStore.subscriptionId The subscription ID of the share's storage account
-## @param certificateStore.resourceGroup The resource group of the share's storage account
-## @param certificateStore.storageAccount The name of the share's storage account
-## @param certificateStore.shareName The name of the share (usually always "certificates")
-## @param certificateStore.fileName The name of the file inside the share to mount as the certificate store in the container (usually always "ca-bundle.crt")
+## @param certificateStore.configMapName The name of the ConfigMap containing the certificate store (usually always "workleap-trust-bundle")
+## @param certificateStore.fileName The name of the file inside the ConfigMap to mount as the certificate store in the container (usually always "ca-certificates.crt")
 certificateStore:
   enabled: false
-  subscriptionId: ""
-  resourceGroup: ""
-  storageAccount: ""
-  shareName: "certificates"
-  fileName: "ca-bundle.crt"
+  configMapName: "workleap-trust-bundle"
+  fileName: "ca-certificates.crt"


### PR DESCRIPTION
With our move from a centralized trust store file to one generated by [trust-manager](https://cert-manager.io/docs/trust/trust-manager/), we are introducing a breaking change that simplifies the `certificateStore` helm values in order to mount the store from an in-cluster configmap rather than a global azure files file share.