### PR TITLE
IDP-2785 Fix typo in deployment certificate store configmap path

### DIFF
--- a/charts/aspnetcore/Chart.yaml
+++ b/charts/aspnetcore/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspnetcore
 description: A generic Helm chart for ASP.NET Core services
-version: 3.0.0
+version: 3.0.1
 home: https://github.com/gsoft-inc/gsoft-helm-charts
 sources:
   - https://github.com/gsoft-inc/gsoft-helm-charts

--- a/charts/aspnetcore/templates/deployment.yaml
+++ b/charts/aspnetcore/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
           optional: false
           items:
           - key: {{ .Values.certificateStore.fileName }}
-            item: {{ .Values.certificateStore.fileName }}
+            path: {{ .Values.certificateStore.fileName }}
       {{- end }}
       {{- if .Values.extraVolumes}}
         {{- toYaml .Values.extraVolumes | nindent 8 }}


### PR DESCRIPTION
Accidentally committed a typo in the deployment yaml that causes the certificate store's volume to be invalid.