### PR TITLE
feat: make aspnetcore chart usable for non-.NET workloads (FENG-2321)

### DIFF
--- a/.github/workflows/ci-aspnetcore.yml
+++ b/.github/workflows/ci-aspnetcore.yml
@@ -130,3 +130,29 @@ jobs:
       - name: Describe test pod
         run: kubectl describe pods --namespace test
         if: always()
+
+      - name: Create non-.NET smoke namespace
+        run: kubectl create namespace nondotnet
+
+      - name: Template Helm chart (non-.NET smoke)
+        run: helm template aspnetcore-nondotnet ./charts/aspnetcore/ --namespace nondotnet --values ./charts/aspnetcore/tests/values-nondotnet.yaml --debug
+
+      - name: Install Helm chart (non-.NET smoke)
+        run: helm install aspnetcore-nondotnet ./charts/aspnetcore/ --namespace nondotnet --values ./charts/aspnetcore/tests/values-nondotnet.yaml --debug --wait
+
+      - name: Show non-.NET resources
+        run: kubectl get all --namespace nondotnet
+        if: always()
+
+      - name: Describe non-.NET test pod
+        run: kubectl describe pods --namespace nondotnet
+        if: always()
+
+      - name: Verify DOTNET_* env vars are absent
+        run: |
+          POD=$(kubectl get pod --namespace nondotnet -l app.kubernetes.io/name=aspnetcore -o jsonpath='{.items[0].metadata.name}')
+          if kubectl exec --namespace nondotnet "$POD" -- env | grep -E '^(DOTNET_ENVIRONMENT|ASPNETCORE_URLS)='; then
+            echo "ERROR: ASP.NET env vars leaked into non-.NET pod"
+            exit 1
+          fi
+          echo "OK: no DOTNET_* env vars present in non-.NET pod"

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,28 @@ tests/schema/autoscaling-cpu-target-too-high: export EXPECTED_ERROR_MESSAGE="(ta
 tests/schema/autoscaling-cpu-target-too-high:
 	@${HELM_TEMPLATE} --set autoscaling.targetCPUUtilizationPercentage=101 ${SHOULD_FAIL_WITH_ERROR_AND_THEN} ${DISPLAY_RESULT}
 
+# Test image.containerPort minimum validation (should fail with 0)
+tests/schema/image-containerport-zero: export TEST_DISPLAY_NAME="Schema should reject image.containerPort=0"
+tests/schema/image-containerport-zero: export EXPECTED_ERROR_MESSAGE="(containerPort.*minimum|Must be greater than or equal to 1)"
+tests/schema/image-containerport-zero:
+	@${HELM_TEMPLATE} --set image.containerPort=0 ${SHOULD_FAIL_WITH_ERROR_AND_THEN} ${DISPLAY_RESULT}
+
+# Test image.containerPort maximum validation (should fail with 70000)
+tests/schema/image-containerport-too-high: export TEST_DISPLAY_NAME="Schema should reject image.containerPort greater than 65535"
+tests/schema/image-containerport-too-high: export EXPECTED_ERROR_MESSAGE="(containerPort.*maximum|Must be less than or equal to 65535)"
+tests/schema/image-containerport-too-high:
+	@${HELM_TEMPLATE} --set image.containerPort=70000 ${SHOULD_FAIL_WITH_ERROR_AND_THEN} ${DISPLAY_RESULT}
+
+# Test image.containerPort accepts a non-default valid value
+tests/schema/image-containerport-valid: export TEST_DISPLAY_NAME="Schema should accept a custom image.containerPort"
+tests/schema/image-containerport-valid:
+	@${HELM_TEMPLATE} --set image.containerPort=3000 ${SHOULD_SUCCEED_AND_THEN} ${DISPLAY_RESULT}
+
+# Test aspnetcore.injectEnvVars=false suppresses DOTNET_* env vars
+tests/schema/aspnetcore-injectenvvars-false: export TEST_DISPLAY_NAME="Disabling injectEnvVars should suppress DOTNET_* env vars"
+tests/schema/aspnetcore-injectenvvars-false:
+	@${HELM_TEMPLATE} --set aspnetcore.injectEnvVars=false 2>&1 | grep -q -v 'DOTNET_ENVIRONMENT' && ${DISPLAY_RESULT}
+
 # Test extraEnvVars missing required name field (should fail)
 tests/schema/extraenvvars-missing-name: export TEST_DISPLAY_NAME="Schema should require name field in extraEnvVars"
 tests/schema/extraenvvars-missing-name: export EXPECTED_ERROR_MESSAGE="(extraEnvVars.*missing property.*name)"

--- a/Makefile
+++ b/Makefile
@@ -218,10 +218,13 @@ tests/schema/image-containerport-valid: export TEST_DISPLAY_NAME="Schema should 
 tests/schema/image-containerport-valid:
 	@${HELM_TEMPLATE} --set image.containerPort=3000 ${SHOULD_SUCCEED_AND_THEN} ${DISPLAY_RESULT}
 
-# Test aspnetcore.injectEnvVars=false suppresses DOTNET_* env vars
+# Test aspnetcore.injectEnvVars=false suppresses DOTNET_* env vars.
+# Captures output first so that a `helm template` failure propagates (a pipe to grep would mask it),
+# then asserts non-presence with an explicit negative check.
 tests/schema/aspnetcore-injectenvvars-false: export TEST_DISPLAY_NAME="Disabling injectEnvVars should suppress DOTNET_* env vars"
 tests/schema/aspnetcore-injectenvvars-false:
-	@${HELM_TEMPLATE} --set aspnetcore.injectEnvVars=false 2>&1 | grep -q -v 'DOTNET_ENVIRONMENT' && ${DISPLAY_RESULT}
+	@OUT="$$(${HELM_TEMPLATE} --set aspnetcore.injectEnvVars=false 2>&1)" && \
+		! echo "$$OUT" | grep -q 'DOTNET_ENVIRONMENT' && ${DISPLAY_RESULT}
 
 # Test extraEnvVars missing required name field (should fail)
 tests/schema/extraenvvars-missing-name: export TEST_DISPLAY_NAME="Schema should require name field in extraEnvVars"

--- a/charts/aspnetcore/Chart.yaml
+++ b/charts/aspnetcore/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspnetcore
 description: A generic Helm chart for ASP.NET Core services
-version: 5.0.0
+version: 5.1.0
 home: https://github.com/workleap/gsoft-helm-charts
 sources:
   - https://github.com/workleap/gsoft-helm-charts

--- a/charts/aspnetcore/templates/deployment.yaml
+++ b/charts/aspnetcore/templates/deployment.yaml
@@ -77,15 +77,19 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.image.containerPort }}
+          {{- if or .Values.aspnetcore.injectEnvVars .Values.extraEnvVars }}
           env:
+          {{- if .Values.aspnetcore.injectEnvVars }}
             - name: DOTNET_ENVIRONMENT
               value: {{ .Values.environment | quote }}
             - name: ASPNETCORE_URLS
-              value: "http://+:8080"
+              value: {{ printf "http://+:%d" (int .Values.image.containerPort) | quote }}
+          {{- end }}
           {{- range .Values.extraEnvVars }}
             - name: {{ .name }}
               value: {{ .value | quote }}
+          {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/aspnetcore/tests/deployment_test.yaml
+++ b/charts/aspnetcore/tests/deployment_test.yaml
@@ -298,3 +298,71 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 10
+
+  - it: should default containerPort to 8080
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+
+  - it: should respect a custom image.containerPort
+    set:
+      image:
+        containerPort: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 3000
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ASPNETCORE_URLS
+            value: "http://+:3000"
+
+  - it: should inject DOTNET_ENVIRONMENT and ASPNETCORE_URLS by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DOTNET_ENVIRONMENT
+            value: "Development"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ASPNETCORE_URLS
+            value: "http://+:8080"
+
+  - it: should not inject DOTNET_* env vars when aspnetcore.injectEnvVars is false
+    set:
+      aspnetcore:
+        injectEnvVars: false
+      extraEnvVars:
+        - name: TEST_VAR
+          value: "kept"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DOTNET_ENVIRONMENT
+            value: "Development"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ASPNETCORE_URLS
+            value: "http://+:8080"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TEST_VAR
+            value: "kept"
+
+  - it: should omit env block entirely when injectEnvVars is false and extraEnvVars is empty
+    set:
+      aspnetcore:
+        injectEnvVars: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].env

--- a/charts/aspnetcore/tests/helpers_integration_test.yaml
+++ b/charts/aspnetcore/tests/helpers_integration_test.yaml
@@ -16,7 +16,7 @@ tests:
         template: service.yaml
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: "aspnetcore-5.0.0"
+          value: "aspnetcore-5.1.0"
         template: service.yaml
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
@@ -75,7 +75,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: "aspnetcore-5.0.0"
+          value: "aspnetcore-5.1.0"
         template: serviceaccount.yaml
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
@@ -99,7 +99,7 @@ tests:
         template: httproute.yaml
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: "aspnetcore-5.0.0"
+          value: "aspnetcore-5.1.0"
         template: httproute.yaml
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]

--- a/charts/aspnetcore/tests/helpers_test.yaml
+++ b/charts/aspnetcore/tests/helpers_test.yaml
@@ -50,7 +50,7 @@ tests:
       # Chart label should include version and handle special characters
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: "aspnetcore-5.0.0"
+          value: "aspnetcore-5.1.0"
       # Should include selector labels
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
@@ -77,7 +77,7 @@ tests:
           value: "v1.2.3-beta"
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: "aspnetcore-5.0.0"
+          value: "aspnetcore-5.1.0"
 
   - it: should handle chart version with plus signs in helm.sh/chart label
     chart:

--- a/charts/aspnetcore/tests/values-nondotnet.yaml
+++ b/charts/aspnetcore/tests/values-nondotnet.yaml
@@ -1,0 +1,36 @@
+# Smoke-test values for a non-.NET workload (FENG-2321).
+# Uses mendhak/http-https-echo (Node/TypeScript HTTP echo server) on a non-default port,
+# with ASP.NET-specific env injection disabled.
+image:
+  registry: docker.io
+  repository: mendhak/http-https-echo
+  tag: "40"
+  pullPolicy: IfNotPresent
+  containerPort: 3000
+
+aspnetcore:
+  injectEnvVars: false
+
+httpRoute:
+  create: false
+
+extraEnvVars:
+  - name: HTTP_PORT
+    value: "3000"
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 3
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 3

--- a/charts/aspnetcore/values.schema.json
+++ b/charts/aspnetcore/values.schema.json
@@ -59,9 +59,27 @@
           "enum": ["Always", "IfNotPresent", "Never"],
           "default": "IfNotPresent",
           "description": "ASP.NET Core image pull policy"
+        },
+        "containerPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 8080,
+          "description": "Container port the workload listens on"
         }
       },
       "required": ["registry", "repository", "tag"],
+      "additionalProperties": false
+    },
+    "aspnetcore": {
+      "type": "object",
+      "properties": {
+        "injectEnvVars": {
+          "type": "boolean",
+          "default": true,
+          "description": "Inject DOTNET_ENVIRONMENT and ASPNETCORE_URLS env vars; set to false for non-.NET workloads"
+        }
+      },
       "additionalProperties": false
     },
     "service": {

--- a/charts/aspnetcore/values.yaml
+++ b/charts/aspnetcore/values.yaml
@@ -23,12 +23,20 @@ commonAnnotations: {}
 ## @param image.repository ASP.NET Core image repository
 ## @param image.tag ASP.NET Core image tag (immutable tags are recommended)
 ## @param image.pullPolicy ASP.NET Core image pull policy
+## @param image.containerPort Container port the workload listens on
 ##
 image:
   registry: mcr.microsoft.com
   repository: dotnet/samples
   tag: aspnetapp
   pullPolicy: IfNotPresent
+  containerPort: 8080
+
+## ASP.NET Core specific behavior
+## @param aspnetcore.injectEnvVars Inject DOTNET_ENVIRONMENT and ASPNETCORE_URLS env vars into the container. Set to false for non-.NET workloads.
+##
+aspnetcore:
+  injectEnvVars: true
 
 ## ASP.NET Core Service parameters.
 ## @param service.name Name of the service, automatically generated from the release name if not specified


### PR DESCRIPTION
Jira issue link: [FENG-2321](https://workleap.atlassian.net/browse/FENG-2321)

## Summary

Adds two additive, backward-compatible knobs to the `aspnetcore` chart so non-.NET workloads (e.g. the TypeScript BFF `wl-app-server`) can use it without forking:

- **`image.containerPort`** (default `8080`) — parameterizes the container port and the rendered `ASPNETCORE_URLS` value, so a non-default port works for both ASP.NET and non-ASP.NET workloads.
- **`aspnetcore.injectEnvVars`** (default `true`) — gates injection of `DOTNET_ENVIRONMENT` and `ASPNETCORE_URLS`. Set to `false` for non-.NET workloads.

Defaults preserve existing behavior — current ASP.NET consumers see no change.

The `env:` block is now omitted entirely when `injectEnvVars=false` and `extraEnvVars` is empty, so we don't render an invalid empty list.

Chart bumped to **5.1.0** (MINOR, additive).

Jira: [FENG-2321](https://workleap.atlassian.net/browse/FENG-2321)

## Why granular over a single `aspnet: true/false` flag

Couples two unrelated decisions (port number vs. env injection). An ASP.NET app on a non-default Kestrel port should not have to disable env injection just to override the port. Granular knobs also avoid a future rename when the chart name no longer matches its usage.

## Coverage

- Five new helm-unittest cases in `tests/deployment_test.yaml` covering: default port, custom port (with `ASPNETCORE_URLS` propagation), default env var injection, env var suppression, and the empty-env edge case.
- Four new Makefile schema tests for `image.containerPort` (min/max/valid) and `aspnetcore.injectEnvVars=false` rendering.
- New CI step in `ci-aspnetcore.yml` that deploys `tests/values-nondotnet.yaml` (Node/TypeScript `mendhak/http-https-echo:40` on port 3000, env injection off) to each Kind cluster in the matrix and asserts no `DOTNET_*` env vars leak into the running pod.

## Test plan

- [x] `helm lint --strict ./charts/aspnetcore/` passes
- [x] `helm unittest charts/aspnetcore` — 105 passed
- [x] `CI=true make tests` — all schema and precheck tests pass (incl. new ones)
- [x] `helm template` diff shows only the `helm.sh/chart` label changing (5.0.0 → 5.1.0); deployment env block / port unchanged for default values
- [x] `helm template -f tests/values-nondotnet.yaml` renders `containerPort: 3000` and only `HTTP_PORT` env var
- [x] Schema rejects `image.containerPort=0` and `=70000`
- [ ] CI Kind matrix (v1.27–v1.30) deploys both default and non-.NET scenarios

## Out of scope

- Non-Deployment workload kinds (Job/StatefulSet/etc.)
- Multi-container / sidecar support
- Chart rename / split

[FENG-2321]: https://workleap.atlassian.net/browse/FENG-2321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

