### PR TITLE
feat: secure-by-default restrictedSecurityContext preset (FENG-2350)

### DIFF
--- a/charts/aspnetcore/Chart.yaml
+++ b/charts/aspnetcore/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspnetcore
 description: A generic Helm chart for ASP.NET Core services
-version: 5.1.0
+version: 5.2.0
 home: https://github.com/workleap/gsoft-helm-charts
 sources:
   - https://github.com/workleap/gsoft-helm-charts

--- a/charts/aspnetcore/MIGRATION.md
+++ b/charts/aspnetcore/MIGRATION.md
@@ -1,5 +1,67 @@
 # Migration Guide
 
+## v5.1 → v5.2
+
+### Restricted security context preset, on by default (behavior change)
+
+A new opinionated preset, `presets.restrictedSecurityContext`, is **enabled by default** in 5.2.0. When enabled, the chart applies a Pod Security Standards "Restricted" baseline to every pod and container it renders:
+
+| Where | Field | Value |
+|---|---|---|
+| Pod   | `securityContext.runAsNonRoot`                | `true` |
+| Container | `securityContext.allowPrivilegeEscalation` | `false` |
+| Container | `securityContext.capabilities.drop`        | `["ALL"]` |
+
+**Why this is the new default**
+
+1. **Secure-by-default mandate.** The Infrastructure team owns this chart and the AKS clusters it deploys to. Workloads should be hardened by virtue of using the shared chart, not by every team remembering to copy a `securityContext` block into their values.
+2. **Pod Security Standards alignment.** These three fields are the load-bearing part of the upstream Kubernetes PSS *Restricted* profile. Charts that already render these settings won't start failing schedule when cluster-layer Pod Security Admission turns on.
+3. **Defense in depth on top of the image.** A Dockerfile `USER` directive is the primary non-root guarantee, but it's image-build-time and author-controlled. `runAsNonRoot: true` is the kubelet-enforced catch-all that refuses to start the pod if a future image accidentally drops `USER`. Dropping all capabilities removes the default container capability set (CHOWN, DAC_OVERRIDE, NET_RAW, SETUID, etc.) that HTTP workloads never need.
+
+**What this might break**
+
+Most modern ASP.NET Core, Node, and static-frontend images already satisfy this baseline. The two real failure modes are:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Pod fails to start: `container has runAsNonRoot and image will run as root` | The image has no `USER` directive (or `USER 0`) | Add `USER <non-root>` to the Dockerfile, or in values set `podSecurityContext: { runAsUser: <uid> }` |
+| Workload can't bind its listening port | Workload binds a privileged port (<1024) and now has no `NET_BIND_SERVICE` capability | Preferred: change the workload to bind a port ≥ 1024. Alternative: in values, set `containerSecurityContext: { capabilities: { add: ["NET_BIND_SERVICE"] } }` (the chart merges this with the preset's drop-ALL) |
+
+**How to extend, not override, the preset**
+
+Two new passthrough values are merged on top of the preset (user keys win over preset keys):
+
+```yaml
+podSecurityContext:
+  fsGroup: 2000          # added to the preset
+  # runAsNonRoot: false  # would override the preset
+
+containerSecurityContext:
+  readOnlyRootFilesystem: true                # added to the preset
+  capabilities:
+    add: ["NET_BIND_SERVICE"]                 # merges with preset's drop: ["ALL"]
+```
+
+**How to opt out entirely**
+
+Only with explicit justification — please document the reason in your values.yaml:
+
+```yaml
+presets:
+  restrictedSecurityContext:
+    enabled: false  # WHY: <reason this workload cannot run restricted>
+```
+
+The chart's existing `securityContext.enabled` (for sysctls) and `securityContext.sysctls` are unchanged and are merged into the pod-level securityContext alongside the preset.
+
+### Migration steps
+
+1. Run `helm template` against each consumer with v5.2.0 (`helm dependency update` + `helm template --version 5.2.0`) and diff against current output.
+2. For any workload whose image runs as root, add a `USER` directive to the Dockerfile **or** add `podSecurityContext.runAsUser` in values.
+3. For any workload binding a privileged port, prefer rebinding to a port ≥ 1024.
+4. If a workload genuinely cannot run under the Restricted profile, set `presets.restrictedSecurityContext.enabled: false` and add an inline comment explaining why.
+
+
 ## v4 → v5
 
 ### PodDisruptionBudget (breaking change)

--- a/charts/aspnetcore/templates/deployment.yaml
+++ b/charts/aspnetcore/templates/deployment.yaml
@@ -42,10 +42,25 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- /*
+        Build effective pod-level securityContext by merging, in order:
+          1. presets.restrictedSecurityContext defaults (when enabled)
+          2. user-provided podSecurityContext (overrides preset)
+          3. sysctls (when securityContext.enabled)
+      */ -}}
+      {{- $podSC := dict }}
+      {{- if .Values.presets.restrictedSecurityContext.enabled }}
+        {{- $_ := set $podSC "runAsNonRoot" true }}
+      {{- end }}
+      {{- if .Values.podSecurityContext }}
+        {{- $podSC = mustMergeOverwrite $podSC .Values.podSecurityContext }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
+        {{- $_ := set $podSC "sysctls" .Values.securityContext.sysctls }}
+      {{- end }}
+      {{- if $podSC }}
       securityContext:
-        sysctls:
-          {{- toYaml .Values.securityContext.sysctls | nindent 10 }}
+        {{- toYaml $podSC | nindent 8 }}
       {{- end }}
       {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
@@ -75,6 +90,23 @@ spec:
         - name: {{ .Chart.Name }}-container
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- /*
+            Build effective container-level securityContext by merging, in order:
+              1. presets.restrictedSecurityContext defaults (when enabled)
+              2. user-provided containerSecurityContext (overrides preset)
+          */ -}}
+          {{- $containerSC := dict }}
+          {{- if .Values.presets.restrictedSecurityContext.enabled }}
+            {{- $_ := set $containerSC "allowPrivilegeEscalation" false }}
+            {{- $_ := set $containerSC "capabilities" (dict "drop" (list "ALL")) }}
+          {{- end }}
+          {{- if .Values.containerSecurityContext }}
+            {{- $containerSC = mustMergeOverwrite $containerSC .Values.containerSecurityContext }}
+          {{- end }}
+          {{- if $containerSC }}
+          securityContext:
+            {{- toYaml $containerSC | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.image.containerPort }}

--- a/charts/aspnetcore/tests/deployment_test.yaml
+++ b/charts/aspnetcore/tests/deployment_test.yaml
@@ -153,15 +153,141 @@ tests:
           path: spec.template.spec.securityContext.sysctls[0].value
           value: "65535"
 
-  - it: should not apply securityContext when disabled
+  - it: should not apply securityContext when both sysctls and restrictedSecurityContext preset are disabled
     set:
       securityContext:
         enabled: false
+      presets:
+        restrictedSecurityContext:
+          enabled: false
     asserts:
       - hasDocuments:
           count: 1
       - isNull:
           path: spec.template.spec.securityContext
+
+  - it: should apply restricted pod securityContext by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+
+  - it: should apply restricted container securityContext by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value: ["ALL"]
+
+  - it: should not apply container securityContext when restrictedSecurityContext preset is disabled and no containerSecurityContext is set
+    set:
+      presets:
+        restrictedSecurityContext:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: should let podSecurityContext override preset fields
+    set:
+      podSecurityContext:
+        runAsNonRoot: false
+        fsGroup: 2000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: false
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+
+  - it: should preserve preset capabilities.drop when containerSecurityContext adds capabilities
+    # Load-bearing assertion: verifies that mustMergeOverwrite recursively
+    # merges nested `capabilities` rather than replacing the whole map. If
+    # the merge ever regresses to a shallow replace, drop:[ALL] silently
+    # disappears whenever a consumer sets capabilities.add — a real security
+    # regression that wouldn't be caught by add-only assertions.
+    set:
+      containerSecurityContext:
+        readOnlyRootFilesystem: true
+        capabilities:
+          add: ["NET_BIND_SERVICE"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value: ["ALL"]
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          value: ["NET_BIND_SERVICE"]
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should render podSecurityContext on its own when preset is disabled
+    set:
+      presets:
+        restrictedSecurityContext:
+          enabled: false
+      podSecurityContext:
+        fsGroup: 2000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+      - isNull:
+          path: spec.template.spec.securityContext.runAsNonRoot
+
+  - it: should render containerSecurityContext on its own when preset is disabled
+    set:
+      presets:
+        restrictedSecurityContext:
+          enabled: false
+      containerSecurityContext:
+        readOnlyRootFilesystem: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext.capabilities
+
+  - it: should merge sysctls and restrictedSecurityContext preset on the pod
+    set:
+      securityContext:
+        enabled: true
+        sysctls:
+          - name: "net.core.somaxconn"
+            value: "65535"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.sysctls[0].name
+          value: "net.core.somaxconn"
 
   - it: should use custom topologySpreadConstraints when provided
     set:

--- a/charts/aspnetcore/tests/helpers_integration_test.yaml
+++ b/charts/aspnetcore/tests/helpers_integration_test.yaml
@@ -16,7 +16,7 @@ tests:
         template: service.yaml
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: "aspnetcore-5.1.0"
+          value: "aspnetcore-5.2.0"
         template: service.yaml
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
@@ -75,7 +75,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: "aspnetcore-5.1.0"
+          value: "aspnetcore-5.2.0"
         template: serviceaccount.yaml
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
@@ -99,7 +99,7 @@ tests:
         template: httproute.yaml
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: "aspnetcore-5.1.0"
+          value: "aspnetcore-5.2.0"
         template: httproute.yaml
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]

--- a/charts/aspnetcore/tests/helpers_test.yaml
+++ b/charts/aspnetcore/tests/helpers_test.yaml
@@ -50,7 +50,7 @@ tests:
       # Chart label should include version and handle special characters
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: "aspnetcore-5.1.0"
+          value: "aspnetcore-5.2.0"
       # Should include selector labels
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
@@ -77,7 +77,7 @@ tests:
           value: "v1.2.3-beta"
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: "aspnetcore-5.1.0"
+          value: "aspnetcore-5.2.0"
 
   - it: should handle chart version with plus signs in helm.sh/chart label
     chart:

--- a/charts/aspnetcore/values.schema.json
+++ b/charts/aspnetcore/values.schema.json
@@ -455,6 +455,14 @@
       },
       "additionalProperties": false
     },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Extra fields merged into the pod's spec.securityContext, on top of presets.restrictedSecurityContext"
+    },
+    "containerSecurityContext": {
+      "type": "object",
+      "description": "Extra fields merged into the container's securityContext, on top of presets.restrictedSecurityContext"
+    },
     "migration": {
       "type": "object",
       "properties": {
@@ -489,6 +497,17 @@
               "type": "boolean",
               "default": true,
               "description": "Configure topologySpreadConstraints for spreading pods across nodes"
+            }
+          },
+          "additionalProperties": false
+        },
+        "restrictedSecurityContext": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Apply Pod Security Standards Restricted baseline (runAsNonRoot, allowPrivilegeEscalation: false, drop ALL caps) to pod and container"
             }
           },
           "additionalProperties": false

--- a/charts/aspnetcore/values.yaml
+++ b/charts/aspnetcore/values.yaml
@@ -240,6 +240,19 @@ securityContext:
   - name: net.ipv4.tcp_keepalive_probes
     value: "8"
 
+## Extra fields merged into the pod-level securityContext, on top of any defaults
+## set by `presets.restrictedSecurityContext` and the sysctls block above.
+## User-provided keys overwrite preset keys. Useful for adding e.g. `fsGroup`.
+## @param podSecurityContext Extra fields merged into the pod's spec.securityContext
+podSecurityContext: {}
+
+## Extra fields merged into the container-level securityContext, on top of any
+## defaults set by `presets.restrictedSecurityContext`. User-provided keys
+## overwrite preset keys. Useful for adding e.g. `readOnlyRootFilesystem: true`
+## or whitelisting a single capability via `capabilities.add: ["NET_BIND_SERVICE"]`.
+## @param containerSecurityContext Extra fields merged into the container's securityContext
+containerSecurityContext: {}
+
 ## Configure settings related to HELM chart migration.
 ## @param migration.existingSelectors.enabled Whether or not to use existing selectors for the deployment
 ## @param migration.existingSelectors.selectors A map of existing selectors to use for the deployment
@@ -253,4 +266,31 @@ presets:
   ## Configure a `topologySpreadConstraints` for the deployment spreading pods across nodes in a best effort way
   ## Setting the chart Values.topologySpreadConstraints will override this preset
   spreadAcrossNodes:
+    enabled: true
+
+  ## Restricted security context preset — ENABLED BY DEFAULT in 5.2.0.
+  ##
+  ## When enabled, the chart applies a Pod Security Standards "Restricted"
+  ## baseline to every pod and container it renders:
+  ##   - Pod  spec.securityContext.runAsNonRoot:                true
+  ##   - Container .securityContext.allowPrivilegeEscalation:   false
+  ##   - Container .securityContext.capabilities.drop:          [ALL]
+  ##
+  ## Rationale (long form: MIGRATION.md, v5.1 → v5.2):
+  ##   1. Secure-by-default — workloads are hardened by using the shared
+  ##      chart, not by every team remembering to add a securityContext block.
+  ##   2. Pod Security Standards Restricted alignment — keeps the chart
+  ##      compatible with cluster-side PSS admission if it is ever enforced.
+  ##   3. Defense in depth on top of the image's USER directive. Drops the
+  ##      default container capability set (CHOWN, DAC_OVERRIDE, NET_RAW,
+  ##      SETUID, etc.) that HTTP workloads never need.
+  ##
+  ## Extend or override individual fields via `podSecurityContext` /
+  ## `containerSecurityContext` above (user keys win over preset keys).
+  ##
+  ## Opt out with `enabled: false` — only with explicit justification, and
+  ## please document the reason inline in your values.yaml.
+  ##
+  ## @param presets.restrictedSecurityContext.enabled Apply the PSS Restricted baseline to pod + container
+  restrictedSecurityContext:
     enabled: true


### PR DESCRIPTION
Jira issue link: [FENG-2350](https://workleap.atlassian.net/browse/FENG-2350)

## Summary

Adds an opinionated preset `presets.restrictedSecurityContext` to the `aspnetcore` chart, **enabled by default** in v5.2.0. When enabled, the chart applies a Pod Security Standards "Restricted" baseline to every pod and container it renders:

| Where | Field | Value |
|---|---|---|
| Pod   | `securityContext.runAsNonRoot`                | `true` |
| Container | `securityContext.allowPrivilegeEscalation` | `false` |
| Container | `securityContext.capabilities.drop`        | `[ALL]` |

Driven by FENG-2350 — wl-app's pre-launch Helm migration needed these guarantees and the underlying chart did not render them.

## Why these are the new defaults

This is the question the change has to justify clearly, so:

1. **Secure-by-default mandate.** The Infrastructure team owns this chart and the AKS clusters it deploys to. Workloads should be hardened by virtue of using the shared chart, not by every team remembering to copy a `securityContext` block into their values. Cost of opting in: 1 flag. Cost of getting this wrong on every workload independently: real attack surface across the fleet.

2. **Pod Security Standards alignment.** `runAsNonRoot`, `allowPrivilegeEscalation: false`, and `capabilities.drop: [ALL]` are the load-bearing fields of the upstream Kubernetes PSS *Restricted* profile. Charts that already render them will not start failing schedule if cluster-side Pod Security Admission is ever turned on.

3. **Defense in depth on top of the image.** A Dockerfile `USER` directive is the primary non-root guarantee, but it's image-build-time and author-controlled. `runAsNonRoot: true` is the kubelet-enforced catch-all that refuses to start the pod if a future image accidentally drops `USER`. Dropping all capabilities removes the default container capability set (CHOWN, DAC_OVERRIDE, NET_RAW, SETUID, etc.) that HTTP workloads never need — a real attack surface that image-level hardening doesn't cover.

## Adoption-profile audit (why this is OK to ship as default-on in a minor)

- **ov-monorepo** (largest consumer, 30+ services) is pinned at chart v3.2.2 on NGINX ingress. It cannot take v5.x at all until the team migrates to Gateway API. Dockerfile spot-checks show services already use `USER app` and bind 8080 — they will tolerate the new defaults whenever they do that bump.
- **wl-app** (FENG-2350) is the first real adopter of v5.x and explicitly wants the restricted profile.
- No other known consumer is on v5.x today.

So the blast radius of default-on is bounded to wl-app (which welcomes it). For future consumers, the secure default IS the desired behavior.

## What's in this PR

- `Chart.yaml`: 5.1.0 → 5.2.0.
- `values.yaml`: adds `presets.restrictedSecurityContext.enabled: true` plus two passthrough values (`podSecurityContext: {}`, `containerSecurityContext: {}`) that merge on top of the preset (user keys win).
- `values.schema.json`: schema entries for the three new keys.
- `templates/deployment.yaml`: renders pod-level and container-level `securityContext`, merging in order: preset → user passthrough → sysctls (`mustMergeOverwrite` for nested map merging).
- `MIGRATION.md`: new "v5.1 → v5.2" section with rationale, failure modes table, extension examples, opt-out instructions.
- Tests: 8 new + 1 modified unittest cases. The key new case verifies that `capabilities.drop: [ALL]` survives when a consumer adds `capabilities.add` — the merge has to be recursive on the nested `capabilities` map, not a shallow replace, or `drop` silently disappears.

## How extension and opt-out work

Extend without losing preset:

\`\`\`yaml
podSecurityContext:
  fsGroup: 2000                              # added to the preset

containerSecurityContext:
  readOnlyRootFilesystem: true               # added to the preset
  capabilities:
    add: [\"NET_BIND_SERVICE\"]              # merges with preset's drop:[ALL]
\`\`\`

Override individual preset fields:

\`\`\`yaml
podSecurityContext:
  runAsNonRoot: false                        # overrides preset for this workload
\`\`\`

Opt out entirely (with a justification comment):

\`\`\`yaml
presets:
  restrictedSecurityContext:
    enabled: false  # WHY: <reason this workload cannot run restricted>
\`\`\`

## Test plan

- [x] \`helm unittest charts/aspnetcore\` — 113/113 pass (was 105 on main; +8 new)
- [x] \`make tests\` (Makefile schema + precheck suite) — all pass
- [x] \`helm template\` smoke runs:
  - Default values + Gateway API parentRefs: pod + container restricted profile renders
  - Preset disabled, no overrides: no securityContext rendered anywhere
  - User \`containerSecurityContext.capabilities.add: [NET_BIND_SERVICE]\`: preset's \`drop: [ALL]\` is preserved, \`add\` is appended, \`readOnlyRootFilesystem\` is layered in
  - Production environment + replicaCount=2: PDB + restricted profile + topology spread coexist cleanly
- [ ] Consumer validation — wl-app (FENG-2350) will validate end-to-end via its PR ephemeral env once it bumps to 5.2.0


[FENG-2350]: https://workleap.atlassian.net/browse/FENG-2350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ