### PR TITLE
ci: auto-generate GitHub release notes + retroactive backfill (FENG-2352)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+# Configuration for GitHub's auto-generated release notes.
+# See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+# Categorization is label-driven: each PR's labels decide which section it
+# lands in. Without label discipline, the wildcard "Other" catch-all keeps
+# every PR visible — strictly better than the previous empty release body.
+# A follow-up could map Conventional Commits prefixes (feat:, fix:, feat!:)
+# to labels via a label-sync workflow; out of scope here.
+changelog:
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking
+        - kind/breaking
+    - title: Features
+      labels:
+        - kind/feature
+        - enhancement
+    - title: Fixes
+      labels:
+        - kind/bug
+        - bug
+    - title: Other
+      labels:
+        - "*"

--- a/.github/workflows/backfill-release-notes.yml
+++ b/.github/workflows/backfill-release-notes.yml
@@ -1,0 +1,87 @@
+name: Backfill release notes
+
+# One-off retroactive populator for historical releases. chart-releaser's
+# --generate-release-notes only fires for newly-created releases, so the
+# bodies of releases created before FENG-2352 stay bare ("A generic Helm
+# chart for ASP.NET Core services") unless we patch them.
+#
+# Run this manually from the Actions tab. It iterates over every existing
+# release, finds the previous release of the same chart, asks GitHub's
+# release-notes API for the diff, and patches the body via `gh release edit`.
+# Idempotent — re-running on an already-backfilled release just overwrites
+# the body with a freshly generated version.
+#
+# After running it once and reviewing the results, this file can be deleted
+# (or kept around for the next time someone manually creates a release).
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "If true, print what would be patched but do not call `gh release edit`."
+        required: false
+        default: "false"
+
+permissions:
+  contents: write
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Backfill every release's notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          # Pre-fetch all releases once; the loop only does in-memory jq
+          # lookups + one generate-notes API call + one edit per release.
+          gh release list --limit 200 --json tagName,createdAt > releases.json
+          total=$(jq 'length' releases.json)
+          echo "Found $total releases."
+
+          # Iterate oldest-first so log output reads in chronological order.
+          jq -r 'sort_by(.createdAt) | .[] | "\(.tagName)\t\(.createdAt)"' releases.json | \
+          while IFS=$'\t' read -r tag created; do
+            # Tag shape is "<chart>-<semver>" (e.g. aspnetcore-5.1.0). Strip
+            # the trailing "-<semver>" to recover the chart name.
+            chart="${tag%-*}"
+
+            # Previous release = most recent release of the SAME chart with
+            # a createdAt strictly earlier than this one's.
+            prev=$(jq -r --arg chart "$chart" --arg created "$created" '
+              [ .[]
+                | select(.tagName | startswith($chart + "-"))
+                | select(.createdAt < $created)
+              ]
+              | sort_by(.createdAt)
+              | last.tagName // empty' releases.json)
+
+            if [ -z "$prev" ]; then
+              echo "SKIP $tag — no prior release of $chart to diff against."
+              continue
+            fi
+
+            notes=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="$tag" \
+              -f previous_tag_name="$prev" \
+              --jq .body)
+
+            if [ -z "$notes" ]; then
+              echo "SKIP $tag — generate-notes returned empty body (vs $prev)."
+              continue
+            fi
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "DRY $tag (vs $prev): would patch with $(echo "$notes" | wc -l) lines of notes."
+            else
+              gh release edit "$tag" --notes "$notes"
+              echo "DONE $tag (vs $prev)."
+            fi
+          done
+
+          rm -f releases.json

--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -48,3 +48,8 @@ jobs:
           CR_PAGES_BRANCH: "gh-pages"
           CR_PAGES_INDEX_PATH: "pages/index.yaml"
           CR_SKIP_EXISTING: "true"
+          # Ask GitHub to auto-generate release notes from merged PRs in the
+          # tag range. chart-releaser binds this to the cr CLI's
+          # --generate-release-notes flag via viper (env prefix CR_, '-' -> '_').
+          # Categorization is driven by .github/release.yml.
+          CR_GENERATE_RELEASE_NOTES: "true"


### PR DESCRIPTION
Jira issue link: [FENG-2352](https://workleap.atlassian.net/browse/FENG-2352)

## Summary

Fixes the long-standing empty-changelog gap on this repo's GitHub releases. Every existing release (~10+ historical) has just the chart description as its body — no PR list, no changelog, no version-bump signal. Renovate bumps and consumer audits get nothing useful.

Two halves, both in this PR (one mergeable unit; the retroactive half is `workflow_dispatch` only, so merging does nothing on its own).

### Going forward — `release-charts.yml` + `.github/release.yml`

chart-releaser's underlying CLI has a `--generate-release-notes` flag (`cr/cmd/upload.go:58`) that asks GitHub's `POST /releases/generate-notes` API to populate the release body (verified at `pkg/github/github.go:112`). The action wrapper doesn't expose it as an input, but cr binds CLI flags to env vars via viper with prefix `CR_` + `-` → `_` (`pkg/config/config.go:80-82`), so setting **`CR_GENERATE_RELEASE_NOTES: \"true\"`** in the existing chart-releaser step's `env:` block is all that's needed.

`.github/release.yml` configures the categorization (Breaking / Features / Fixes / Other). Without PR labels, the `\"*\"` catch-all puts everything into \"Other\" — strictly better than today's empty body. Conventional-Commits-prefix auto-labelling is a separate follow-up if categorized output becomes important.

### Retroactive — `backfill-release-notes.yml`

chart-releaser's flag only fires for newly-created releases. Existing releases need the same `generate-notes` API call manually + a `gh release edit` to update the body. New `workflow_dispatch` workflow that walks every release, finds the previous release of the same chart, calls the API, and patches the body. Idempotent. Supports a `dry_run` input so the first run can be eyeballed before any body is touched.

After running it once and reviewing the output, the workflow file can be deleted (or kept around for future need).

## Why this collapses to ~120 added lines

My first cut on this had a custom shell post-step calling `gh api .../generate-notes` after chart-releaser. Reading the chart-releaser source showed that was unnecessary — the CLI already does exactly that when `--generate-release-notes` is set, and env-var binding via viper means I just need to flip one env var. The custom post-step was deleted before this PR.

## Caveats

- **Label-only categorization.** `.github/release.yml` does not parse Conventional Commits prefixes natively. Either label PRs manually, or add a label-sync workflow later. Today's PRs without labels still appear in the changelog — they just land in \"Other\".
- **Single-chart repo today.** The tag-range scope for generate-notes covers all repo activity (not just chart files). A docs-only or CI-only PR between two \`aspnetcore\` releases will appear in \`aspnetcore\`'s changelog. Low noise today; revisit if a second chart is added (path-filter the PRs, or label-exclude non-chart PRs).
- **First release of any chart** has no previous tag — backfill skips it; body stays bare. Acceptable.
- **`gh release edit --notes \"\"`** would blank the body. The backfill script guards against empty notes.

## Test plan

- [x] Verified `cr upload --generate-release-notes` exists in chart-releaser CLI (read source)
- [x] Verified viper env-var binding (CR_GENERATE_RELEASE_NOTES → --generate-release-notes flag)
- [x] Verified chart-releaser-action invokes \`cr upload\` and inherits env vars
- [x] Verified \`.github/release.yml\` schema against [GitHub docs](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options)
- [ ] **Going-forward validation:** triggered automatically by the next chart release (FENG-2350's eventual `aspnetcore-5.2.0` release will be the first one with auto-generated notes if this lands first). Eyeball the release body on GitHub.
- [ ] **Retroactive validation:** run `Backfill release notes` from the Actions tab with `dry_run: true` first, eyeball the log lines (one per release: \"DRY \<tag\> (vs \<prev\>): would patch with N lines of notes\"), then re-run with `dry_run: false` to actually patch the bodies. Spot-check 2–3 release pages after.

## Related

- [FENG-2352](https://workleap.atlassian.net/browse/FENG-2352) — full proposal + verified mechanics
- [FENG-2350](https://workleap.atlassian.net/browse/FENG-2350) / #132 — sibling PR; if this lands first, FENG-2350's v5.2.0 release will be the first one with an auto-generated changelog (proving out the going-forward fix)

[FENG-2352]: https://workleap.atlassian.net/browse/FENG-2352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
